### PR TITLE
Add support for Laravel 13.x

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,8 @@ jobs:
             php: 8.1
           - laravel: 12.*
             php: 8.1
+          - laravel: 12.*
+            php: 8.2
           - laravel: 13.*
             php: 8.1
           - laravel: 13.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,14 +9,18 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
           - laravel: 11.*
             php: 8.1
           - laravel: 12.*
             php: 8.1
+          - laravel: 13.*
+            php: 8.1
+          - laravel: 13.*
+            php: 8.2
         include:
           - laravel: 10.*
             testbench: ^8.0
@@ -24,15 +28,17 @@ jobs:
             testbench: ^9.0
           - laravel: 12.*
             testbench: ^10.0
+          - laravel: 13.*
+            testbench: ^11.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}
@@ -55,6 +61,6 @@ jobs:
         run: vendor/bin/phpunit
 
       - name: Upload PHP test coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
           - laravel: 10.*
             testbench: ^8.0
           - laravel: 11.*
-            testbench: ^9.0
+            testbench: ^9.2
           - laravel: 12.*
             testbench: ^10.0
           - laravel: 13.*

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
         "spatie/laravel-dashboard": "^3.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.5",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "phpunit/phpunit": "^10.5|^11.5.3"
+        "mockery/mockery": "^1.6",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^10.5|^11.5.3|^12.0|^13.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## What's changed

### Composer
- Added `orchestra/testbench ^11.0` and `phpunit/phpunit ^12.0|^13.0` to the existing dev dependency ranges
- Bumped `mockery/mockery` to `^1.6`
- No runtime constraint changes needed — `spatie/laravel-dashboard ^3.0` supports Laravel 13 as of 3.3.1, and `fidum/laravel-dashboard-chart-tile ^6.0` flows through it

### CI
- Added PHP 8.5 and Laravel 13.* to the test matrix
- Laravel 13 excluded on PHP 8.1/8.2 (framework requires ^8.3), mapped to testbench ^11.0
- Bumped `actions/checkout` and `actions/cache` to v4, `codecov/codecov-action` to v5 (v3 is deprecated)

## Verification

Ran the suite locally on PHP 8.5 replicating the workflow install step for Laravel 13 (prefer-stable + prefer-lowest), Laravel 11 (prefer-stable) and Laravel 10 (prefer-stable + prefer-lowest) — all 39 tests / 125 assertions pass in every combination, so no PHP 8.5 matrix exclusions were needed. Older Laravel versions emit a few PHP 8.5 deprecation notices from dependencies but nothing fails.